### PR TITLE
Topbar compacted to navbar with minor UI changes and new battery icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <kbd>
-   <img src="/client/logo.png" alt="Xivi 15" style="border-radius: 50%; width: 120px; height: auto;">
+   <img src="/client/logo.png" alt="Xivi15" style="border-radius: 50%; width: 120px; height: auto;">
 </kbd>
 </p>
 
-<h1>Xivi 15</h1>
+<h1>Xivi15</h1>
 
 ## Features
 - [x] Unique and Appealing UI
@@ -20,7 +20,7 @@
 ## Setup
 
 > [!IMPORTANT]  
-> Due to how Xivi 15 is setup, Numerous hosters won't work properly.
+> Xivi instances (until universal drive is released) have completely seperate databases, they do not share any data between each other.
 
 #### !!! You will need [Bun](https://bun.sh/) (not NodeJS) before setting up your own Xivi instance !!!
 #### !!! Xivi CANNOT run with Windows or macOS as the instance server, please use Linux to set up your instance instead !!!
@@ -35,4 +35,4 @@ bun run pm2:start
 ```
 
 ## Join us
-If you would like to support the development and get further information on Xivi 15, You can join the discord [here](http://dsc.gg/xiviservices). 
+If you would like to support the development and get further information on Xivi, You can join the discord [here](http://dsc.gg/xiviservices). 

--- a/client/src/components/apps/Settings.tsx
+++ b/client/src/components/apps/Settings.tsx
@@ -77,7 +77,7 @@ export function Settings() {
             <RadioGroup
               value={taskbarMode}
               onValueChange={(value) => 
-                updateSettings({ taskbarMode: value as 'normal' | 'chrome' | 'windows11' })
+                updateSettings({ taskbarMode: value as 'normal' | 'centeredapps' | 'allcentered' })
               }
               className="flex flex-col space-y-1"
             >
@@ -86,12 +86,12 @@ export function Settings() {
                 <Label htmlFor="normal">Normal (Left-aligned)</Label>
               </div>
               <div className="flex items-center space-x-2">
-                <RadioGroupItem value="chrome" id="chrome" />
-                <Label htmlFor="chrome">Chrome OS style</Label>
+                <RadioGroupItem value="centeredapps" id="centeredapps" />
+                <Label htmlFor="centeredapps">Apps Centered</Label>
               </div>
               <div className="flex items-center space-x-2">
-                <RadioGroupItem value="windows11" id="windows11" />
-                <Label htmlFor="windows11">Windows 11 style</Label>
+                <RadioGroupItem value="allcentered" id="allcentered" />
+                <Label htmlFor="allcentered">Completely Centered</Label>
               </div>
             </RadioGroup>
           </div>

--- a/client/src/components/desktop/Taskbar.tsx
+++ b/client/src/components/desktop/Taskbar.tsx
@@ -1,47 +1,67 @@
-import { Button } from '@/components/ui/button'
-import { useState } from 'react'
-import { useDesktopStore } from '@/store/desktop'
-import { StartMenu } from './StartMenu'
-import { ContextMenu } from './ContextMenu'
-import { nanoid } from 'nanoid'
-import { AppWindow, Layout } from 'lucide-react'
-import { appIcons, getAppIcon } from '@/lib/appIcons'
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Power, Maximize2 } from 'lucide-react';
+import { useDesktopStore } from '@/store/desktop';
+import { StartMenu } from './StartMenu';
+import { ContextMenu } from './ContextMenu';
+import { nanoid } from 'nanoid';
+import { AppWindow, Layout } from 'lucide-react';
+import { appIcons, getAppIcon } from '@/lib/appIcons';
+import Battery from '@/components/ui/battery';
 
 export function Taskbar() {
-  const { windows, activeWindowId, pinnedApps, setActiveWindow, toggleMinimize, addWindow, taskbarMode } = useDesktopStore()
-  const [showStartMenu, setShowStartMenu] = useState(false)
+  const { windows, activeWindowId, pinnedApps, setActiveWindow, toggleMinimize, addWindow, taskbarMode } = useDesktopStore();
+  const [showStartMenu, setShowStartMenu] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
     appId: string;
     appComponent: string;
     appTitle: string;
-  } | null>(null)
+  } | null>(null);
+  const [dateTime, setDateTime] = useState('');
 
-  const handleRightClick = (
-    e: React.MouseEvent,
-    appId: string,
-    appComponent: string,
-    appTitle: string
-  ) => {
-    e.preventDefault()
+  useEffect(() => {
+    const updateTime = () => {
+      const now = new Date();
+      setDateTime(now.toLocaleString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      }));
+    };
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleRightClick = (e: React.MouseEvent, appId: string, appComponent: string, appTitle: string) => {
+    e.preventDefault();
     setContextMenu({
       x: e.clientX,
       y: e.clientY,
       appId,
       appComponent,
       appTitle,
-    })
-  }
+    });
+  };
 
   const handlePinnedAppClick = (app: { component: string; title: string }) => {
-    // Check if the app is already open
-    const existingWindow = windows.find((w) => w.component === app.component)
+    const existingWindow = windows.find((w) => w.component === app.component);
     if (existingWindow) {
       if (activeWindowId === existingWindow.id) {
-        toggleMinimize(existingWindow.id)
+        toggleMinimize(existingWindow.id);
       } else {
-        setActiveWindow(existingWindow.id)
+        setActiveWindow(existingWindow.id);
       }
     } else {
       addWindow({
@@ -56,16 +76,41 @@ export function Taskbar() {
         },
         isMinimized: false,
         isMaximized: false,
-      })
+      });
     }
-  }
+  };
+
+  const handleRestart = () => {
+    window.location.reload();
+  };
 
   return (
     <>
       <div className="fixed bottom-0 left-0 right-0 h-12 bg-background/80 backdrop-blur-md border-t flex items-center px-2 z-[9999]">
-        {taskbarMode !== 'windows11' && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-6 w-6 mr-2">
+              <Power className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="menu-transition">
+            <DropdownMenuItem onClick={handleRestart}>Restart</DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                document.body.classList.add('fade-out');
+                setTimeout(() => {
+                  window.close();
+                }, 300);
+              }}
+            >
+              Shut Down
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {taskbarMode !== 'allcentered' && (
           <Button
-            variant={showStartMenu ? "secondary" : "ghost"}
+            variant={showStartMenu ? 'secondary' : 'ghost'}
             size="icon"
             className="mr-2"
             onClick={() => setShowStartMenu(!showStartMenu)}
@@ -73,13 +118,17 @@ export function Taskbar() {
             <Layout className="h-5 w-5" />
           </Button>
         )}
-        
-        <div className={`flex-1 flex items-center space-x-1 taskbar-content ${
-          taskbarMode === 'chrome' || taskbarMode === 'windows11' ? 'justify-center' : ''
-        }`}>
-          {taskbarMode === 'windows11' && (
+
+        <div
+          className={`flex-1 flex items-center space-x-1 taskbar-content ${
+            taskbarMode === 'centeredapps' || taskbarMode === 'allcentered'
+              ? 'justify-center'
+              : ''
+          }`}
+        >
+          {taskbarMode === 'allcentered' && (
             <Button
-              variant={showStartMenu ? "secondary" : "ghost"}
+              variant={showStartMenu ? 'secondary' : 'ghost'}
               size="icon"
               className="mr-2"
               onClick={() => setShowStartMenu(!showStartMenu)}
@@ -87,14 +136,13 @@ export function Taskbar() {
               <Layout className="h-5 w-5" />
             </Button>
           )}
-          {/* Pinned Apps */}
-            {pinnedApps.map((app) => {
-              const Icon = getAppIcon(app.component)
-              if (!Icon || !app.component || !app.title) {
-                return null
-              }
-              return (
-                <Button
+          {pinnedApps.map((app) => {
+            const Icon = getAppIcon(app.component);
+            if (!Icon || !app.component || !app.title) {
+              return null;
+            }
+            return (
+              <Button
                 key={app.component}
                 variant="ghost"
                 size="icon"
@@ -103,50 +151,56 @@ export function Taskbar() {
                 onContextMenu={(e) =>
                   handleRightClick(e, '', app.component, app.title)
                 }
-                >
+              >
                 <Icon className="h-4 w-4" />
-                </Button>
-              )
-            })}
+              </Button>
+            );
+          })}
           <div className="w-px h-6 bg-border mx-2" />
-          {/* Open Windows */}
           {windows.map((window) => {
-            const Icon = appIcons[window.component] || AppWindow
+            const Icon = appIcons[window.component] || AppWindow;
             return (
               <Button
                 key={window.id}
                 data-window-id={window.id}
-                variant={activeWindowId === window.id ? "secondary" : "ghost"}
+                variant={activeWindowId === window.id ? 'secondary' : 'ghost'}
                 className="h-8 px-2 text-sm"
                 onClick={() => {
                   if (activeWindowId === window.id) {
-                    toggleMinimize(window.id)
+                    toggleMinimize(window.id);
                   } else {
-                    setActiveWindow(window.id)
+                    setActiveWindow(window.id);
                   }
                 }}
                 onContextMenu={(e) =>
-                  handleRightClick(e, window.id, window.component, window.title)
+                  handleRightClick(
+                    e,
+                    window.id,
+                    window.component,
+                    window.title
+                  )
                 }
               >
                 <Icon className="h-4 w-4 mr-2" />
                 {window.title}
               </Button>
-            )
+            );
           })}
         </div>
-      </div>
-      
-      {showStartMenu && (
-        <StartMenu onClose={() => setShowStartMenu(false)} />
-      )}
 
+        <div className="absolute right-40 text-sm pointer-events-none select-none">
+          <Battery />
+        </div>
+
+        <div className="absolute right-2 text-sm pointer-events-none select-none">
+          {dateTime}
+        </div>
+      </div>
+
+      {showStartMenu && <StartMenu onClose={() => setShowStartMenu(false)} />}
       {contextMenu && (
-        <ContextMenu
-          {...contextMenu}
-          onClose={() => setContextMenu(null)}
-        />
+        <ContextMenu {...contextMenu} onClose={() => setContextMenu(null)} />
       )}
     </>
-  )
+  );
 }

--- a/client/src/components/desktop/TopBar.tsx
+++ b/client/src/components/desktop/TopBar.tsx
@@ -1,17 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Power, Maximize2 } from 'lucide-react';
+import { Maximize2 } from 'lucide-react';
 
 export function TopBar() {
-  const [dateTime, setDateTime] = useState('');
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false); // Added state for menu visibility
 
   const toggleFullscreen = () => {
     if (!document.fullscreenElement) {
@@ -23,68 +15,8 @@ export function TopBar() {
     }
   };
 
-  useEffect(() => {
-    const updateTime = () => {
-      const now = new Date();
-      setDateTime(now.toLocaleString('en-US', {
-        weekday: 'short',
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }));
-    };
-
-    updateTime();
-    const interval = setInterval(updateTime, 1000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const handleShutdown = () => {
-    // Add fade-out animation before closing
-    document.body.classList.add('fade-out');
-    setTimeout(() => {
-      window.close();
-    }, 300); // Adjust duration as needed
-  };
-
-  const handleRestart = () => {
-    window.location.reload();
-  };
-
-  const handleMenuOpen = () => {
-    setMenuOpen(true);
-  };
-
-  const handleMenuClose = () => {
-    setMenuOpen(false);
-  };
-
-
   return (
-    <div className="fixed top-0 left-0 right-0 h-8 bg-background/80 backdrop-blur-md border-b flex items-center px-2 z-[9999]">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button 
-            variant="ghost" 
-            size="icon" 
-            className="h-6 w-6 menu-transition"
-            onClick={handleMenuOpen}
-          >
-            <Power className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="menu-transition" onChange={(open) => !open && handleMenuClose()}>
-          <DropdownMenuItem onClick={handleRestart}>
-            Restart
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleShutdown}>
-            Shut Down
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
+    <div className="fixed top-0 left-0 right-0 h-8 bg-background/80 backdrop-blur-md border-b flex items-center px-2 z-[9999] hidden">
       <Button
         variant="ghost"
         size="icon"
@@ -95,7 +27,6 @@ export function TopBar() {
       </Button>
 
       <div className="flex-1" />
-      <div className="text-sm">{dateTime}</div>
     </div>
   );
 }

--- a/client/src/components/desktop/Window.tsx
+++ b/client/src/components/desktop/Window.tsx
@@ -106,13 +106,13 @@ export function Window({ id, title, children, position, isMinimized, isMaximized
       ref={windowRef}
       className={cn(
         'absolute flex flex-col rounded-lg overflow-hidden bg-background/80 backdrop-blur-md border shadow-lg fade-in window-transition',
-        isMaximized && 'fixed !left-0 !right-0 !top-8 !bottom-12'
+        isMaximized && 'fixed !left-0 !right-0 !top-0 !bottom-12'
       )}
       style={{
         left: position?.x ?? 100,
-        top: position?.y ?? 40, // Start below topbar
+        top: position?.y ?? 44,
         width: isMaximized ? '100%' : (position?.width ?? 600),
-        height: isMaximized ? 'calc(100% - 88px)' : (position?.height ?? 400), // Account for topbar and taskbar
+        height: isMaximized ? 'calc(100% - 58px)' : (position?.height ?? 400), // Account for topbar and taskbar
         zIndex
       }}
       onClick={() => setActiveWindow(id)}

--- a/client/src/components/ui/battery.tsx
+++ b/client/src/components/ui/battery.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+
+declare global {
+  interface BatteryManager {
+    level: number;
+    charging: boolean;
+    addEventListener: (type: string, listener: () => void) => void;
+  }
+  interface Navigator {
+    getBattery?: () => Promise<BatteryManager>;
+  }
+}
+
+const Battery = () => {
+  const [batteryLevel, setBatteryLevel] = useState<number>(100);
+  const [isCharging, setIsCharging] = useState<boolean>(false);
+  const [isHovering, setIsHovering] = useState<boolean>(false);
+
+  useEffect(() => {
+    if ("getBattery" in navigator) {
+      navigator.getBattery?.().then((battery) => {
+        setBatteryLevel(Math.round(battery.level * 100));
+        setIsCharging(battery.charging);
+        battery.addEventListener("levelchange", () =>
+          setBatteryLevel(Math.round(battery.level * 100))
+        );
+        battery.addEventListener("chargingchange", () =>
+          setIsCharging(battery.charging)
+        );
+      });
+    }
+  }, []);
+
+  const getBatteryColor = (): string => {
+    if (batteryLevel >= 75) return "bg-green-500";
+    if (batteryLevel >= 50) return "bg-yellow-400";
+    if (batteryLevel >= 25) return "bg-orange-500";
+    return "bg-red-500";
+  };
+
+  return (
+    <div className="relative flex flex-col items-center justify-center">
+      <div
+        className="w-2.5 h-5 border border-white flex items-end overflow-hidden"
+        style={{ borderRadius: "3px" }}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+      >
+        <div className={`${getBatteryColor()} w-full`} style={{ height: `${batteryLevel}%` }}></div>
+      </div>
+      {isHovering && (
+        <div className="tooltip absolute bottom-[110%] left-1/2 transform -translate-x-1/2 bg-black text-white px-2 py-1 rounded text-xs whitespace-nowrap z-10">
+          {batteryLevel}% {isCharging ? "(Charging)" : ""}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Battery;


### PR DESCRIPTION
Added to taskbar and removed from topbar.

Topbar Adjustments:

Moved the power and time elements from the topbar to the navbar.

Hid the topbar entirely, as the fullscreen button was its only function and is no longer needed.

Adjusted window sizing so that windows now extend to the top of the screen.

Settings Renaming:

Renamed some settings keys related to navbar styling for better clarity and consistency. This includes relabeling the (windows 11 style) and (chrome OS) style to options that better match what they do.