### PR TITLE
Fix markdown violations in README, update install steps, readd `bun run dev` and fullscreen button from the top bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 <h1>Xivi15</h1>
 
 ## Features
+
 - [x] Unique and Appealing UI
 - [x] Wide selection of games
-- [x] Customizable switchable proxy 
+- [x] Customizable switchable proxy
 - [x] Fully functional built-in AI
 - [x] Custom built-in Music Player
 - [x] Numerous adjustable settings
 - [x] Variety of useful features
 - [x] Custom built-in Files System
 - [x] Partially functional terminal
- 
-      
+
 ## Setup
 
 > [!IMPORTANT]  
@@ -26,13 +26,15 @@
 #### !!! Xivi CANNOT run with Windows or macOS as the instance server, please use Linux to set up your instance instead !!!
 
 Setup commands:
-```
+
+```sh
 git clone https://github.com/xiviorg/Xivi15.git
 cd Xivi15
-bun install
+bun install --frozen-lockfile
 bun run cmd:production
 bun run pm2:start
 ```
 
 ## Join us
-If you would like to support the development and get further information on Xivi, You can join the discord [here](http://dsc.gg/xiviservices). 
+
+If you would like to support the development and get further information on Xivi, You can join the discord [here](http://dsc.gg/xiviservices).

--- a/client/src/components/desktop/Taskbar.tsx
+++ b/client/src/components/desktop/Taskbar.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Power, Maximize2 } from 'lucide-react';
+import { Power, Maximize2, Minimize2 } from 'lucide-react';
 import { useDesktopStore } from '@/store/desktop';
 import { StartMenu } from './StartMenu';
 import { ContextMenu } from './ContextMenu';
@@ -26,6 +26,7 @@ export function Taskbar() {
     appTitle: string;
   } | null>(null);
   const [dateTime, setDateTime] = useState('');
+  const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement);
 
   useEffect(() => {
     const updateTime = () => {
@@ -83,6 +84,25 @@ export function Taskbar() {
   const handleRestart = () => {
     window.location.reload();
   };
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen();
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  useEffect(() => {
+    const handlefschange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', handlefschange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handlefschange);
+    };
+  }, []);
 
   return (
     <>
@@ -188,13 +208,29 @@ export function Taskbar() {
           })}
         </div>
 
-        <div className="absolute right-40 text-sm pointer-events-none select-none">
+        <div
+          style={{ right: '12.5rem' }}
+          className="absolute text-sm pointer-events-none select-none"
+        >
           <Battery />
         </div>
 
-        <div className="absolute right-2 text-sm pointer-events-none select-none">
+        <div className="absolute right-12 text-sm pointer-events-none select-none">
           {dateTime}
         </div>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-2 h-8 px-2 text-sm"
+          onClick={toggleFullscreen}
+        >
+          {isFullscreen ? (
+            <Minimize2 className="h-4 w-4" />
+          ) : (
+            <Maximize2 className="h-4 w-4" />
+          )}
+        </Button>
       </div>
 
       {showStartMenu && <StartMenu onClose={() => setShowStartMenu(false)} />}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
+    "dev": "vite dev",
     "dev:dev": "vite dev",
     "build": "mkdir -p ./dist/ && vite build && cp -r ./server/* ./dist/ && cp ./vite.config.ts ./dist/vite.config.ts",
     "start": "[ -f ./.env ] && source ./.env; bun dist/index.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev:dev": "echo This script doesn\\'t work yet. Please use the build and start scripts instead. # bun server/index.ts",
+    "dev:dev": "vite dev",
     "build": "mkdir -p ./dist/ && vite build && cp -r ./server/* ./dist/ && cp ./vite.config.ts ./dist/vite.config.ts",
     "start": "[ -f ./.env ] && source ./.env; bun dist/index.ts",
     "dev:check": "bun tsc",


### PR DESCRIPTION
Fixes multiple markdown violations in the README and updates the installation steps to require a frozen lockfile.
Readds `bun run dev` and ensures `bun run dev:dev` works for backwards compatibilty.
Readds fullscreen button to the taskbar from the top bar that was removed in https://github.com/xiviorg/Xivi15/commit/f1e107a1f75a4ec9b3800687beb63b16d6ead3d4.